### PR TITLE
Better password reset flow

### DIFF
--- a/client/routes.js
+++ b/client/routes.js
@@ -3,6 +3,7 @@ import welcome from './views/welcome.vue';
 import signin from './views/signin.vue';
 import register from './views/register.vue';
 import forgotPassword from './views/forgot-password.vue';
+import resetPassword from './views/reset-password.vue';
 import moderation from './views/moderation.vue';
 
 export default [
@@ -13,6 +14,13 @@ export default [
     { path: '/signin/forgot-username', component: signin },
     { path: '/register', component: register },
     { path: '/forgot-password', component: forgotPassword },
+    { path: '/reset-password',
+      props: route => ({
+        token: route.query.t,
+        username: route.query.u
+      }),
+      component: resetPassword,
+    },
     { path: '/moderation', component: moderation },
     { path: '/:pathMatch(.*)*', component: dashboard },
 ];

--- a/client/routes.js
+++ b/client/routes.js
@@ -10,17 +10,11 @@ export default [
     { path: '/', component: dashboard },
     { path: '/welcome', component: welcome },
     { path: '/signin', component: signin },
-    { path: '/signin/reset-password', component: signin },
+    { path: '/signin/forgot-password', component: signin },
     { path: '/signin/forgot-username', component: signin },
     { path: '/register', component: register },
     { path: '/forgot-password', component: forgotPassword },
-    { path: '/reset-password',
-      props: route => ({
-        token: route.query.t,
-        username: route.query.u
-      }),
-      component: resetPassword,
-    },
+    { path: '/reset-password', component: resetPassword, },
     { path: '/moderation', component: moderation },
     { path: '/:pathMatch(.*)*', component: dashboard },
 ];

--- a/client/views/forgot-password.vue
+++ b/client/views/forgot-password.vue
@@ -86,7 +86,7 @@ export default defineComponent({
               body: JSON.stringify({ username: this.forgotPasswordUsername }),
           })
               .then((response) => {
-                  this.$router.push('/signin/reset-password');
+                this.$router.push('/signin/forgot-password');
               })
               .catch((response) => {
                   let errors = [{ message: 'An error occurred, please try again later.' }];

--- a/client/views/reset-password.vue
+++ b/client/views/reset-password.vue
@@ -1,0 +1,123 @@
+<style lang="scss">
+#forgotPassword {
+    width: 620px;
+}
+
+</style>
+
+<template>
+    <div id="forgotPasswordContainer">
+        <modal id="forgotPassword" :shown="true" :blackout="true">
+        <p v-if="message" class="lpSuccess">
+            {{ message }}
+        </p>
+        <form id="accountForm" @submit.prevent="resetPassword" >
+            <div class="lpFields">
+                <input type="hidden" name="token" class="token" :value="token">
+                <input type="hidden" name="username" class="username" :value="username">
+                <input v-model="newPassword" type="password" placeholder="New Password" name="newPassword" class="newPassword">
+                <input v-model="confirmNewPassword" type="password" placeholder="Confirm New Password" name="confirmNewPassword" class="confirmNewPassword">
+            </div>
+
+            <errors :errors="errors" />
+
+            <div class="lpButtons">
+                <button class="lpButton" @click="updateAccount">
+                    Submit
+                    <spinner v-if="saving" />
+                </button>
+            </div>
+        </form>
+        </modal>
+        <blackoutFooter />
+        <globalAlerts />
+    </div>
+</template>
+
+<script>
+import { defineComponent } from 'vue';
+
+import blackoutFooter from '../components/blackout-footer.vue';
+import errors from '../components/errors.vue';
+import modal from '../components/modal.vue';
+import spinner from '../components/spinner.vue';
+import globalAlerts from '../components/global-alerts.vue';
+
+export default defineComponent({
+  name: 'ResetPassword',
+
+  components: {
+    blackoutFooter,
+    globalAlerts,
+    errors,
+    modal,
+    spinner,
+  },
+
+  data() {
+    return {
+      errors: [],
+      saving: false,
+      newPassword: '',
+      confirmNewPassword: '',
+      token: '',
+      username: '',
+    };
+  },
+
+  computed: {
+    message() {
+      return '';
+    },
+  },
+
+  mounted() {
+    this.token = this.$route.query.t;
+    this.username = this.$route.query.u;
+  },
+
+  methods: {
+    resetPassword() {
+      this.errors = [];
+
+      if (this.newPassword && this.newPassword != this.confirmNewPassword) {
+        this.errors.push({ field: 'newPassword', message: 'Your passwords don\'t match.' });
+      }
+
+      if (this.newPassword && (this.newPassword.length < 8 || this.newPassword.length > 60)) {
+        this.errors.push({ field: 'newPassword', message: 'Please enter a password between 8 and 60 characters.' });
+      }
+
+      if (this.errors.length) {
+        return;
+      }
+
+      const req = {
+        t: this.token,
+        u: this.username,
+        newPassword: this.newPassword,
+        confirmNewPassword: this.confirmNewPassword,
+      };
+      this.saving = true;
+
+      fetchJson('/pw', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        credentials: 'same-origin',
+        body: JSON.stringify(req),
+      })
+        .then((response) => {
+          this.saving = false;
+          this.shown = false;
+          this.$router.push('/signin/reset-password');
+        })
+        .catch((err) => {
+          this.errors = err;
+          this.saving = false;
+        });
+    },
+  },
+});
+</script>

--- a/client/views/reset-password.vue
+++ b/client/views/reset-password.vue
@@ -111,6 +111,7 @@ export default defineComponent({
         .then((response) => {
           this.saving = false;
           this.shown = false;
+          this.$router.replace({'query': null});
           this.$router.push('/signin/reset-password');
         })
         .catch((err) => {

--- a/client/views/signin.vue
+++ b/client/views/signin.vue
@@ -40,8 +40,11 @@ export default defineComponent({
 
   computed: {
       message() {
-          if (this.$route.path.indexOf('/reset-password') > -1 || this.$route.path.indexOf('/forgot-username') > -1) {
+          if (this.$route.path.indexOf('/forgot-username') > -1 || this.$route.path.indexOf('/forgot-password') > -1) {
               return 'An email has been sent to the address associated with your account. Please reach out via GitHub if you do not receive your email.';
+          }
+          if (this.$route.path.indexOf('/reset-password') > -1 ) {
+              return 'Your password has been reset to the value you provided.';
           }
           return '';
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grampacker",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grampacker",
-      "version": "2.2.3",
+      "version": "2.3.0",
       "license": "GPL-2.0",
       "dependencies": {
         "@babel/core": "7.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grampacker",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "description": "Gram Packer is a website to track the gear you take on adventures. It is a fork of LighterPack.",
   "main": "app.js",
   "scripts": {

--- a/server/views.js
+++ b/server/views.js
@@ -31,6 +31,7 @@ const vueRoutes = [ /* TODO - get this from same data source as Vue */
     { path: '/welcome' },
     { path: '/register' },
     { path: '/forgot-password' },
+    { path: '/reset-password' },
     { path: '/moderation' },
 ];
 


### PR DESCRIPTION
## Old

User asks for new password. Their current password is blanked, a new one is generated, and that new password is sent to the email on file.

This was not great:
* Sending live passwords over email is not great
* Malicious users could reset victims' passwords whenever they wanted

## New

1. Someone requests a password reset for Alice
2. Alice receives an email with a token and her username in a link
3. If she wants to reset her password, she clicks on the link and chooses a password.
4. Tokens expire after three hours

